### PR TITLE
HSTS Support

### DIFF
--- a/app/cfg.py
+++ b/app/cfg.py
@@ -54,6 +54,10 @@ def cfg_frontend(vhost):
         frontend.append("reqadd X-Forwarded-Proto:\ https")
         frontend.append("redirect scheme https code 301 if !{ ssl_fc }"),
         frontend.append("bind 0.0.0.0:443 %s" % SSL)
+        frontend.append('acl secure dst_port eq 44")
+        frontend.append('redirect scheme https if !{ ssl_fc }')
+        frontend.append('rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains;\ preload')
+        frontend.append('rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure if secure')
     if vhost:
         added_vhost = set()
         for _, domain_names in vhost.iteritems():

--- a/app/cfg.py
+++ b/app/cfg.py
@@ -54,7 +54,7 @@ def cfg_frontend(vhost):
         frontend.append("reqadd X-Forwarded-Proto:\ https")
         frontend.append("redirect scheme https code 301 if !{ ssl_fc }"),
         frontend.append("bind 0.0.0.0:443 %s" % SSL)
-        frontend.append('acl secure dst_port eq 44")
+        frontend.append('acl secure dst_port eq 443')
         frontend.append('redirect scheme https if !{ ssl_fc }')
         frontend.append('rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains;\ preload')
         frontend.append('rsprep ^Set-Cookie:\ (.*) Set-Cookie:\ \1;\ Secure if secure')


### PR DESCRIPTION
This is the the frontend bits for HSTS support. It only gets enabled if SSL is enabled. 

Need to figure out how to put this in the backend section, for when SSL is enabled.  
``` 
http-request set-header X-Forwarded-Port %[dst_port] 
http-request add-header X-Forwarded-Proto https if { ssl_fc } 
```

see https://blog.bigdinosaur.org/how-to-cache-https-with-varnish-using-haproxy/ for more information on HSTS with haproxy.