### PR TITLE
fix typo introduced with extra_bind_settings

### DIFF
--- a/haproxy/haproxy.py
+++ b/haproxy/haproxy.py
@@ -270,7 +270,7 @@ class Haproxy(object):
                 if self.ssl:
                     ssl = True
 
-            bind = " ".join([self.port_num, self.extra_bind_settings.get(port_num, "")])
+            bind = " ".join([port_num, self.extra_bind_settings.get(port_num, "")])
             if ssl:
                 bind = " ".join([bind.strip(), self.ssl])
 


### PR DESCRIPTION
I was getting the following error with the latest build:

`2015-10-07T11:34:05.992770620Z ERROR:root:'Haproxy' object has no attribute 'port_num'`

traced it back to a typo introduced with https://github.com/tutumcloud/haproxy/commit/4a01ce3bd724a6166a82be1d877564cbc61e57d3