### PR TITLE
add monitor-uri support to expose a ping/healthcheck url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 |EXTRA_BIND_SETTINGS|<empty>|comma-separated string(<port>:<setting>) of extra settings, and each part will be appended to the related port bind section in the configuration file. To escape comma, use `\,`. Possible vaule: `443:accept-proxy, 80:name http`|
 |HTTP_BASIC_AUTH|<empty>|a comma-separated list of credentials(`<user>:<pass>`) for HTTP basic auth, which applies to all the backend routes. To escape comma, use `\,`. *Attention:* DO NOT rely on this for authentication in production|
 |CA_CERT|<empty>|CA cert for haproxy to verify the client. Use the same format as `DEFAULT_SSL_CERT`|
+|MONITOR_URI|/ping|uri to use for [HAProxy:monitor-uri](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-monitor-uri)|
+|MONITOR_PORT|80|port to use for [HAProxy:monitor-uri](http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-monitor-uri)|
 
 ###Settings in linked application services###
 

--- a/haproxy/haproxy.py
+++ b/haproxy/haproxy.py
@@ -226,7 +226,7 @@ class Haproxy(object):
                                "stats uri /",
                                "stats auth %s" % cls.envvar_stats_auth]
 
-        cfg["frontend monitor"] = ["bind %s" % cls.envvar_monitor_port, "monitor-uri %s" % cls.envvar_monitor_uri]
+        cfg["frontend monitor"] = ["bind :%s" % cls.envvar_monitor_port, "monitor-uri %s" % cls.envvar_monitor_uri]
 
         for opt in cls.envvar_option:
             if opt:

--- a/haproxy/haproxy.py
+++ b/haproxy/haproxy.py
@@ -32,6 +32,8 @@ class Haproxy(object):
     envvar_extra_default_settings = os.getenv("EXTRA_DEFAULT_SETTINGS")
     envvar_extra_bind_settings = os.getenv("EXTRA_BIND_SETTINGS")
     envvar_http_basic_auth = os.getenv("HTTP_BASIC_AUTH")
+    envvar_monitor_uri = os.getenv("MONITOR_URI", "/ping")
+    envvar_monitor_port = os.getenv("MONITOR_PORT", "80")
 
     # envvar overwritable
     envvar_balance = os.getenv("BALANCE", "roundrobin")
@@ -223,6 +225,8 @@ class Haproxy(object):
                                "stats realm Haproxy\ Statistics",
                                "stats uri /",
                                "stats auth %s" % cls.envvar_stats_auth]
+
+        cfg["frontend monitor"] = ["bind %s" % cls.envvar_monitor_port, "monitor-uri %s" % cls.envvar_monitor_uri]
 
         for opt in cls.envvar_option:
             if opt:


### PR DESCRIPTION
Exposing monitor-uri so that load balancers such as AWS ELB can use it to do [health checking](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_HealthCheck.html).

Not sure if this can be integrated with the existing `envvar_health_check`, but I've added 2 new environment variables.