### PR TITLE
Support Multiple SSL Certificates terminating at HAProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 |env var|default|description|
 |:-----:|:-----:|:----------|
 |DEFAULT_SSL_CERT||Default ssl cert, a pem file with private key followed by public certificate, '\n'(two chars) as the line separator.|
+|EXTRA_SSL_CERTS||List of extra certificate names separated by space, eg. `CERT1 CERT2 CERT3`. You also need to specify each certifcate as an env variable like so `CERT1="<cert-body>", CERT2="<cert-body2>"`|
 |BALANCE|roundrobin|load balancing algorithm to use. Possible values include: `roundrobin`, `static-rr`, `source`, `leastconn`. See:[HAProxy:balance](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-balance)|
 |MODE|http|mode of load balancing for HAProxy. Possible values include: `http`, `tcp`, `health`|
 |MAXCONN|4096|sets the maximum per-process number of concurrent connections.|

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Settings in this part is immutable, you have to redeploy HAProxy service to make
 |env var|default|description|
 |:-----:|:-----:|:----------|
 |DEFAULT_SSL_CERT||Default ssl cert, a pem file with private key followed by public certificate, '\n'(two chars) as the line separator.|
-|EXTRA_SSL_CERTS||List of extra certificate names separated by space, eg. `CERT1 CERT2 CERT3`. You also need to specify each certifcate as an env variable like so `CERT1="<cert-body>", CERT2="<cert-body2>"`|
+|EXTRA_SSL_CERTS||List of extra certificate names separated by space, eg. `CERT1 CERT2 CERT3`. You also need to specify each certifcate as separate env variables like so: `CERT1="<cert-body1>"`, `CERT2="<cert-body2>"`, `CERT3="<cert-body3>"`|
 |BALANCE|roundrobin|load balancing algorithm to use. Possible values include: `roundrobin`, `static-rr`, `source`, `leastconn`. See:[HAProxy:balance](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4-balance)|
 |MODE|http|mode of load balancing for HAProxy. Possible values include: `http`, `tcp`, `health`|
 |MAXCONN|4096|sets the maximum per-process number of concurrent connections.|

--- a/haproxy/haproxy.py
+++ b/haproxy/haproxy.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("haproxy")
 class Haproxy(object):
     # envvar
     envvar_default_ssl_cert = os.getenv("DEFAULT_SSL_CERT") or os.getenv("SSL_CERT")
+    envvar_extra_ssl_certs = os.getenv("EXTRA_SSL_CERTS")
     envvar_default_ca_cert = os.getenv("CA_CERT")
     envvar_maxconn = os.getenv("MAXCONN", "4096")
     envvar_mode = os.getenv("MODE", "http")
@@ -142,6 +143,7 @@ class Haproxy(object):
             certs.append(self.envvar_default_ssl_cert)
         if self.envvar_default_ca_cert:
             cacerts.append(self.envvar_default_ca_cert)
+        certs.extend(self.get_extra_ssl_certs())
         certs.extend(self.specs.get_default_ssl_cert())
         certs.extend(self.specs.get_ssl_cert())
         if certs:
@@ -156,6 +158,12 @@ class Haproxy(object):
                 self.ssl_updated = True
                 self._save_ca_certs(cacerts)
             self.ssl += " ca-file /cacerts/cert0.pem verify required"
+
+    def get_extra_ssl_certs(self):
+        extra_certs = []
+        for cert_name in self.envvar_extra_ssl_certs.split():
+            extra_certs.append(os.getenv(cert_name))
+        return extra_certs
 
     def _save_certs(self, certs):
         try:

--- a/haproxy/haproxy.py
+++ b/haproxy/haproxy.py
@@ -161,8 +161,9 @@ class Haproxy(object):
 
     def get_extra_ssl_certs(self):
         extra_certs = []
-        for cert_name in self.envvar_extra_ssl_certs.split():
-            extra_certs.append(os.getenv(cert_name))
+        if self.envvar_extra_ssl_certs:
+            for cert_name in self.envvar_extra_ssl_certs.split():
+                extra_certs.append(os.getenv(cert_name))
         return extra_certs
 
     def _save_certs(self, certs):


### PR DESCRIPTION
Currently HAProxy only caters for multiple SSL certificates by specifying them in downstream linked Services. We need to serve multiple SSL certificates at HAProxy level, to be shared by ALL linked downstream services. Rather than specifying different SSL certificates per service.

This PR will allow for such functionality. By specifying the environments variables:

`EXTRA_SSL_CERTS=CERT1 CERT2`

and

`CERT1=<cert body1>`
`CERT2=<cert body2>`

Please review and happy to discuss in more details. 